### PR TITLE
Add Dokploy deployment support with health checks

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,6 +13,10 @@ NOSANDBOX=true
 # Browser viewport size (width x height)
 VIEWPORT_SIZE="1280,720"
 
+# --- Dokploy / server deployment settings ---
+# Bind address for the MCP server (set to 0.0.0.0 for Dokploy/Traefik)
+# MCP_HOST=0.0.0.0
+
 # --- Settings for headed mode (uncomment and modify as needed) ---
 # DISPLAY=:0
 # WAYLAND_DISPLAY=wayland-0

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,12 @@ RUN mkdir -p /home/playwright/.npm && chown -R playwright:playwright /home/playw
 # Switch to non-root user
 USER playwright
 
+# Expose the default MCP port
+EXPOSE 8931
+
+# Health check: verify the MCP server is responding
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+  CMD wget -q --spider http://localhost:${MCP_PORT:-8931}/sse || exit 1
+
 # Set the entrypoint
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -2,25 +2,8 @@ services:
   playwright-mcp:
     build: .
     tty: true
-    environment:
-      # Server deployment: always headless
-      - HEADLESS=true
-      # Internal container port for the MCP server
-      - MCP_PORT=${MCP_PORT:-8931}
-      # Bind to 0.0.0.0 so Traefik can reach the container
-      - MCP_HOST=0.0.0.0
-      # Run in isolated mode
-      - ISOLATED=${ISOLATED:-true}
-      # Disable Chrome sandbox (required in containerized environments)
-      - NOSANDBOX=${NOSANDBOX:-true}
-      # Browser viewport size
-      - VIEWPORT_SIZE=${VIEWPORT_SIZE:-1280,720}
-    networks:
-      - dokploy-network
+    ports:
+      - 8931
     restart: unless-stopped
     # Increase shared memory for Chrome stability
     shm_size: "1gb"
-
-networks:
-  dokploy-network:
-    external: true

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -1,0 +1,26 @@
+services:
+  playwright-mcp:
+    build: .
+    tty: true
+    environment:
+      # Server deployment: always headless
+      - HEADLESS=true
+      # Internal container port for the MCP server
+      - MCP_PORT=${MCP_PORT:-8931}
+      # Bind to 0.0.0.0 so Traefik can reach the container
+      - MCP_HOST=0.0.0.0
+      # Run in isolated mode
+      - ISOLATED=${ISOLATED:-true}
+      # Disable Chrome sandbox (required in containerized environments)
+      - NOSANDBOX=${NOSANDBOX:-true}
+      # Browser viewport size
+      - VIEWPORT_SIZE=${VIEWPORT_SIZE:-1280,720}
+    networks:
+      - dokploy-network
+    restart: unless-stopped
+    # Increase shared memory for Chrome stability
+    shm_size: "1gb"
+
+networks:
+  dokploy-network:
+    external: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,11 @@ if [ -n "$MCP_PORT" ]; then
   MCP_ARGS="$MCP_ARGS --port $INTERNAL_PORT"
 fi
 
+# Add --host if MCP_HOST is set (e.g. 0.0.0.0 for Dokploy/Traefik)
+if [ -n "$MCP_HOST" ]; then
+  MCP_ARGS="$MCP_ARGS --host $MCP_HOST"
+fi
+
 # Add --isolated if ISOLATED environment variable is true
 if [ "$ISOLATED" = "true" ]; then
   MCP_ARGS="$MCP_ARGS --isolated"

--- a/template.toml
+++ b/template.toml
@@ -1,0 +1,18 @@
+[variables]
+main_domain = "${domain}"
+
+[[config.domains]]
+serviceName = "playwright-mcp"
+port = 8931
+host = "${main_domain}"
+
+[config.env]
+HEADLESS = "true"
+MCP_PORT = "8931"
+MCP_HOST = "0.0.0.0"
+ISOLATED = "true"
+NOSANDBOX = "true"
+VIEWPORT_SIZE = "1280,720"
+
+[config]
+mounts = []


### PR DESCRIPTION
## Summary
This PR adds support for deploying the Playwright MCP server to Dokploy with proper containerization, health checks, and configuration management.

## Key Changes
- **New Dokploy configuration files**:
  - `template.toml`: Dokploy template configuration with domain binding, port mapping, and environment variables
  - `docker-compose.dokploy.yml`: Docker Compose configuration optimized for Dokploy with 1GB shared memory for Chrome stability

- **Enhanced Dockerfile**:
  - Added `EXPOSE 8931` to document the MCP server port
  - Implemented health check using `wget` to verify MCP server responsiveness on the `/sse` endpoint
  - Health check configured with 30s interval, 10s timeout, 15s startup grace period, and 3 retries

- **Updated entrypoint script**:
  - Added support for `MCP_HOST` environment variable to bind the server to specific addresses (e.g., `0.0.0.0` for Dokploy/Traefik)
  - Allows flexible network configuration for reverse proxy setups

- **Updated environment documentation**:
  - Added `MCP_HOST` configuration option to `.env.sample` with usage notes for Dokploy/Traefik deployments

## Implementation Details
- The health check monitors the MCP server's SSE endpoint to ensure the service is operational
- The `MCP_HOST` binding enables the server to work behind reverse proxies like Traefik
- Shared memory size is increased to 1GB to ensure Chrome/Playwright stability in containerized environments
- All changes maintain backward compatibility with existing deployments

https://claude.ai/code/session_01HkcRxQRTM419wdCAHCQRGu