### PR TITLE
fix: bind server to 0.0.0.0 and add meaningful health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,9 @@ RUN mkdir -p /home/playwright/.npm && chown -R playwright:playwright /home/playw
 # Switch to non-root user
 USER playwright
 
+# Add health check to monitor container health
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD pgrep -f "@playwright/mcp" > /dev/null || exit 1
+
 # Set the entrypoint
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,10 +11,10 @@ if [ "$HEADLESS" = "true" ]; then
   MCP_ARGS="$MCP_ARGS --headless"
 fi
 
-# Add --port if MCP_PORT is set (for SSE connection)
-# This allows SSE connection even when HEADLESS=true
+# Add --port and --host if MCP_PORT is set (for SSE connection)
+# --host 0.0.0.0 is required so Docker port forwarding can reach the server
 if [ -n "$MCP_PORT" ]; then
-  MCP_ARGS="$MCP_ARGS --port $INTERNAL_PORT"
+  MCP_ARGS="$MCP_ARGS --port $INTERNAL_PORT --host 0.0.0.0"
 fi
 
 # Add --isolated if ISOLATED environment variable is true


### PR DESCRIPTION
## Problem

Two bugs affect all users running this as a Docker container.

### 1. ECONNRESET on all client connections

`@playwright/mcp` defaults to binding on `localhost` (127.0.0.1) inside the container. Docker's port forwarding routes traffic to the container's `eth0` IP — not loopback — so every MCP client connection is immediately reset (`ECONNRESET`).

**Fix:** Pass `--host 0.0.0.0` in `entrypoint.sh` so the server listens on all interfaces.

### 2. Health check reports false positives

The container had no `HEALTHCHECK`. Without one, Docker always reports the container as healthy even if the `@playwright/mcp` process crashes after startup.

**Fix:** Add a `HEALTHCHECK` using `pgrep` to verify the process is actually running.

## Changes

- `entrypoint.sh`: add `--host 0.0.0.0` alongside `--port`
- `Dockerfile`: add `HEALTHCHECK` that checks the process is alive

## Verification

After the fix, `curl http://localhost:8931/sse` returns `200 OK` with a live `text/event-stream` response. Before the fix it returned `ECONNRESET`.